### PR TITLE
Add pricing info for top 55 text models as of 11/6

### DIFF
--- a/data/scatterplot-data.json
+++ b/data/scatterplot-data.json
@@ -1030,16 +1030,6 @@
     "model_source": "https://cloud.tencent.com/document/product/1729/104753"
   },
   {
-    "name": "mai-1-preview",
-    "model_api_name": "mai-1-preview",
-    "input_token_price": "",
-    "output_token_price": "",
-    "organization": "Microsoft AI",
-    "license": "Proprietary",
-    "price_source": "",
-    "model_source": "https://microsoft.ai/news/two-new-in-house-models/"
-  },
-  {
     "name": "qwen3-235b-a22b-no-thinking",
     "model_api_name": "qwen3-235b-a22b-no-thinking",
     "input_token_price": "0.7",


### PR DESCRIPTION
- To create the most up-to-date score-cost graph for Google, we add pricing data for 55 new text models that are on the public full text leaderboard as of 11/6
- `mai-1-preview` removed from its position below `hunyuan-t1-20250711` because it has no available pricing data and is in preview mode