### PR TITLE
Display `visibility-data.json` updates in localhost

### DIFF
--- a/scatterplot.html
+++ b/scatterplot.html
@@ -203,14 +203,18 @@
   <div id="scatterplot" class="scatterplot-container"></div>
 
   <script>
+   const PUBLIC_DATA_PREFIX = "https://raw.githubusercontent.com/lmarena/arena-catalog/main/data" 
+   const LOCAL_DATA_PREFIX = "./data"
+   const IS_LOCAL_DEV = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
+   const URL_PREFIX = IS_LOCAL_DEV ? LOCAL_DATA_PREFIX : PUBLIC_DATA_PREFIX  
    Promise.all([
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/scatterplot-data.json"),
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/leaderboard-text.json"),
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/visibility-data.json"),
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/leaderboard-text-style-control.json"),
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/leaderboard-vision.json"),
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/leaderboard-vision-style-control.json"),
-        d3.json("https://raw.githubusercontent.com/lmarena/arena-catalog/main/data/leaderboard-image.json")
+        d3.json(`${URL_PREFIX}/scatterplot-data.json`),
+        d3.json(`${URL_PREFIX}/leaderboard-text.json`),
+        d3.json(`${URL_PREFIX}/visibility-data.json`),
+        d3.json(`${URL_PREFIX}/leaderboard-text-style-control.json`),
+        d3.json(`${URL_PREFIX}/leaderboard-vision.json`),
+        d3.json(`${URL_PREFIX}/leaderboard-vision-style-control.json`),
+        d3.json(`${URL_PREFIX}/leaderboard-image.json`)
       ]).then(function  ([data1, data2, data3, data4, data5, data6, data7]) {
       const slider = document.getElementById("scale-slider");
       const infoIcon = document.querySelector('.info-icon');


### PR DESCRIPTION
- Faster iteration when updating labels on the scatterplot by enabling visibility data updates in localhost